### PR TITLE
Implements the ability to rename and restore internal functions

### DIFF
--- a/test_helpers.c
+++ b/test_helpers.c
@@ -325,7 +325,7 @@ static PHP_RSHUTDOWN_FUNCTION(test_helpers)
 	test_helpers_free_handler(&THG(new_handler).fci TSRMLS_CC);
 	test_helpers_free_handler(&THG(exit_handler).fci TSRMLS_CC);
 
-    zend_hash_destroy(&THG(modified_internal_functions));
+	zend_hash_destroy(&THG(modified_internal_functions));
 	FREE_HASHTABLE(&THG(modified_internal_functions));
 	
 	return SUCCESS;

--- a/tests/rename_internal_function.phpt
+++ b/tests/rename_internal_function.phpt
@@ -4,8 +4,6 @@ rename_function() and internal functions
 <?php 
 if (!extension_loaded('test_helpers')) die('skip test_helpers extension not loaded');
 ?>
---XFAIL--
-Not yet implemented
 --FILE--
 <?php
 $headers = array();

--- a/tests/restore_internal_functions.phpt
+++ b/tests/restore_internal_functions.phpt
@@ -1,0 +1,26 @@
+--TEST--
+restore_internal_functions() resets internal functions after renaming an internal function
+--SKIPIF--
+<?php 
+if (!extension_loaded('test_helpers')) die('skip test_helpers extension not loaded');
+?>
+--FILE--
+<?php
+
+function my_date($format, $time=NULL)
+{
+	return "FORMAT: $format";
+}
+
+rename_function('date', 'date_old');
+rename_function('my_date', 'date');
+
+echo date('Y-m-d'), PHP_EOL;
+
+restore_internal_functions();
+
+echo date('Y-m-d', strtotime("2011-02-14 12:00")), PHP_EOL;
+
+--EXPECT--
+FORMAT: Y-m-d
+2011-02-14


### PR DESCRIPTION
Implemented by creating a HashTable to keep track of the original zend functions, and an userland function to walk that HashTable and restore the original functions.
